### PR TITLE
fix process is not defined error by defining NEXT_PUBLIC_SECURE_SITE_…

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,11 @@ export default defineConfig(({ mode }) => {
   console.log('[vite] Building with base path:', basePath);
   return {
     base: basePath,
+    define: {
+      'process.env.NEXT_PUBLIC_SECURE_SITE_ORIGIN': JSON.stringify(
+        env.NEXT_PUBLIC_SECURE_SITE_ORIGIN || 'https://secure.walletconnect.org'
+      ),
+    },
     plugins: [react(), TanStackRouterVite()],
     resolve: {
       alias: {


### PR DESCRIPTION
Problème :

lors de la migration de walletConnect vers reown, une erreur `Uncaught ReferenceError: process is not defined` apparaît. cela se produit parce que le code essaie d'accéder à ` process.env`, qui est un objet global disponible dans node.js mais pas dans les navigateurs web.

Solution :

pour résoudre cette erreur, il faut définir explicitement process.env.NEXT_PUBLIC_SECURE_SITE_ORIGIN dans la configuration vite.

